### PR TITLE
feat: allowed voters

### DIFF
--- a/src/main.nr
+++ b/src/main.nr
@@ -8,7 +8,7 @@ contract EasyPrivateVoting {
         keys::getters::{get_nsk_app, get_public_keys},
         macros::{functions::{initializer, internal, private, public}, storage::storage, notes::note},
         note::{note_interface::NullifiableNote, utils::compute_note_hash_for_nullify},
-        prelude::{AztecAddress, Map, PublicImmutable, PublicMutable, PrivateSet, NoteHeader, NoteGetterOptions},
+        prelude::{AztecAddress, Map, PublicImmutable, PublicMutable, PrivateSet, NoteHeader, NoteGetterOptions, SharedMutable},
         protocol_types::{hash::poseidon2_hash_with_separator, constants::GENERATOR_INDEX__NOTE_NULLIFIER},
         encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         utils::comparison::Comparator,
@@ -22,6 +22,8 @@ contract EasyPrivateVoting {
         vote_ended: PublicMutable<bool, Context>, // vote_ended is boolean
         active_at_block: PublicImmutable<u32, Context>, // when people can start voting
         delegations: PrivateSet<DelegateNote, Context>, // set of delegations
+
+        allowed_voters: Map<AztecAddress, SharedMutable<bool, 1, Context>, Context>, // allowed voters
     }
 
     #[note]
@@ -81,9 +83,41 @@ contract EasyPrivateVoting {
         storage.active_at_block.initialize(context.block_number() as u32);
     }
 
+    #[public]
+    fn add_voter(voter: AztecAddress) {
+        assert(storage.admin.read().eq(context.msg_sender()), "Only admin can add voters");
+        storage.allowed_voters.at(voter).schedule_value_change(true);
+    }
+
+    #[public]
+    fn add_voters(voters: [AztecAddress; 32]) {
+        assert(storage.admin.read().eq(context.msg_sender()), "Only admin can add voters");
+        for i in 0..31 {
+            let voter = voters[i];
+            if (!voter.is_zero()) {
+                storage.allowed_voters.at(voter).schedule_value_change(true);
+            }
+        }
+    }
+
+    #[public]
+    fn is_voter_allowed(voter: AztecAddress) -> bool {
+        let allowed = storage.allowed_voters.at(voter).get_current_value();
+        allowed
+    }
+
+    #[contract_library_method]
+    fn _is_voter_allowed(context: &mut PrivateContext, storage: Storage<&mut PrivateContext>) -> bool {
+        let allowed = storage.allowed_voters.at(context.msg_sender()).get_current_value();
+        allowed
+    }
+
     #[private]
     // annotation to mark function as private and expose private context
     fn cast_vote(candidate: Field) {
+
+        assert(_is_voter_allowed(&mut context, storage), "sender is not allowed to vote");
+
         let msg_sender_npk_m_hash = get_public_keys(context.msg_sender()).npk_m.hash();
 
         let secret = context.request_nsk_app(msg_sender_npk_m_hash); // get secret key of caller of function
@@ -97,6 +131,9 @@ contract EasyPrivateVoting {
     #[private]
     // sample method for creating a note for someone else to vote on your behalf
     fn delegate_vote(delegatee: AztecAddress, randomness: Field) {
+
+        assert(_is_voter_allowed(&mut context, storage), "sender is not allowed to vote");
+
         let msg_sender_npk_m_hash = get_public_keys(context.msg_sender()).npk_m.hash();
 
         let secret = context.request_nsk_app(msg_sender_npk_m_hash); // get secret key of caller of function

--- a/src/test/first.nr
+++ b/src/test/first.nr
@@ -1,6 +1,7 @@
 use crate::test::utils;
 use dep::aztec::oracle::{execution::get_block_number, storage::storage_read};
 use dep::aztec::protocol_types::storage::map::derive_storage_slot_in_map;
+use dep::aztec::prelude::{AztecAddress};
 
 use crate::EasyPrivateVoting;
 
@@ -52,11 +53,16 @@ unconstrained fn test_fail_end_vote_by_non_admin() {
 
 #[test]
 unconstrained fn test_cast_vote() {
-    let (env, voting_contract_address, _) = utils::setup();
+    let (env, voting_contract_address, admin) = utils::setup();
     let alice = env.create_account();
-    env.impersonate(alice);
+
+    env.impersonate(admin);
+    EasyPrivateVoting::at(voting_contract_address).add_voter(alice).call(&mut env.public());
+    env.advance_block_by(1);
+
 
     let candidate = 1;
+    env.impersonate(alice);
     env.advance_block_by(6);
     EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate).call(&mut env.private());
 
@@ -71,9 +77,14 @@ unconstrained fn test_cast_vote() {
 
 #[test]
 unconstrained fn test_cast_vote_with_separate_accounts() {
-    let (env, voting_contract_address, _) = utils::setup();
+    let (env, voting_contract_address, admin) = utils::setup();
     let alice = env.create_account();
     let bob = env.create_account();
+
+    env.impersonate(admin);
+    EasyPrivateVoting::at(voting_contract_address).add_voter(alice).call(&mut env.public());
+    EasyPrivateVoting::at(voting_contract_address).add_voter(bob).call(&mut env.public());
+    env.advance_block_by(1);
 
     let candidate = 101;
 
@@ -96,13 +107,18 @@ unconstrained fn test_cast_vote_with_separate_accounts() {
 
 #[test]
 unconstrained fn test_cast_vote_with_delegation() {
-    let (env, voting_contract_address, _) = utils::setup();
+    let (env, voting_contract_address, admin) = utils::setup();
     let alice = env.create_account();
     let bob = env.create_account();
 
     let candidate = 101;
     let random = 420;
     
+    env.impersonate(admin);
+    EasyPrivateVoting::at(voting_contract_address).add_voter(alice).call(&mut env.public());
+    env.advance_block_by(1);
+
+
     env.impersonate(alice);
     env.advance_block_by(1);
     EasyPrivateVoting::at(voting_contract_address).delegate_vote(bob, random).call(&mut env.private());
@@ -122,7 +138,7 @@ unconstrained fn test_cast_vote_with_delegation() {
 
 #[test]
 unconstrained fn test_cast_vote_with_multiple_delegations() {
-    let (env, voting_contract_address, _) = utils::setup();
+    let (env, voting_contract_address, admin) = utils::setup();
     let alice = env.create_account();
     let bob = env.create_account();
     let carl = env.create_account();
@@ -132,6 +148,20 @@ unconstrained fn test_cast_vote_with_multiple_delegations() {
     let candidate = 101;
     let random = 420;
     
+    env.impersonate(admin);
+    // EasyPrivateVoting::at(voting_contract_address).add_voter(alice).call(&mut env.public());
+    // EasyPrivateVoting::at(voting_contract_address).add_voter(bob).call(&mut env.public());
+    // EasyPrivateVoting::at(voting_contract_address).add_voter(carl).call(&mut env.public());
+    // EasyPrivateVoting::at(voting_contract_address).add_voter(dave).call(&mut env.public());
+    let mut voters = [AztecAddress::zero(); 32];
+    voters[0] = alice;
+    voters[1] = bob;
+    voters[2] = carl;
+    voters[3] = dave;
+    EasyPrivateVoting::at(voting_contract_address).add_voters(voters).call(&mut env.public());
+    env.advance_block_by(3);
+
+
     env.impersonate(alice);
     env.advance_block_by(1);
     EasyPrivateVoting::at(voting_contract_address).delegate_vote(delegatee, random).call(&mut env.private());
@@ -221,4 +251,51 @@ unconstrained fn test_fail_vote_and_delegate() {
     // Delegate vote as alice
     env.advance_block_by(1);
     EasyPrivateVoting::at(voting_contract_address).delegate_vote(bob, random).call(&mut env.private());
+}
+
+#[test(should_fail)]
+unconstrained fn test_fail_non_allowed_voter() {
+    let (env, voting_contract_address, _) = utils::setup();
+    let alice = env.create_account();
+    let bob = env.create_account();
+
+    let candidate = 101;
+    let random = 420;
+
+    env.impersonate(alice);
+    env.advance_block_by(1);
+    EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate).call(&mut env.private());
+
+    env.advance_block_by(1);
+    EasyPrivateVoting::at(voting_contract_address).delegate_vote(bob, random).call(&mut env.private());
+}
+
+#[test]
+unconstrained fn test_add_voter() {
+    let (env, voting_contract_address, admin) = utils::setup();
+    let alice = env.create_account();
+
+    env.impersonate(admin);
+    EasyPrivateVoting::at(voting_contract_address).add_voter(alice).call(&mut env.public());
+    env.advance_block_by(1);
+
+    assert(EasyPrivateVoting::at(voting_contract_address).is_voter_allowed(alice).call(&mut env.public()));
+}
+
+#[test]
+unconstrained fn test_add_voters() {
+    let (env, voting_contract_address, admin) = utils::setup();
+
+    let mut voters = [AztecAddress::zero(); 32];
+    for i in 0..3 {
+        voters[i] = env.create_account();
+    }
+
+    env.impersonate(admin);
+    EasyPrivateVoting::at(voting_contract_address).add_voters(voters).call(&mut env.public());
+    env.advance_block_by(1);
+
+    for i in 0..3 {
+        assert(EasyPrivateVoting::at(voting_contract_address).is_voter_allowed(voters[i]).call(&mut env.public()));
+    }
 }


### PR DESCRIPTION
- Add `allowed_voters` to storage as a `Map<AztecAddress, SharedMutable<bool>>`
- The admin can add new allowed addresses, either individually or using an array of addresses
- `_is_voter_allowed` and `is_voter_allowed` are virtually the same function; one is used internally, and the other is exposed in the interface
- Add small tests